### PR TITLE
Updated regex to avoid matching JavaScript regex

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -89,7 +89,7 @@ class ViewParseAjaxHandler(BaseHandler):
         discoveredLinks = []
         outputLinks = []
         # ugh lol
-        regex = "(`|'|\")([\/]([_a-zA-Z0-9\-\_]+))+"
+        regex = "[^/][`'\"]([\/][a-zA-Z0-9_.-]+)+(?!\/g|i|m|u|y|;|,)"
         links = re.finditer(regex, contents) 
         for link in links:
             linkStr = link.group(0)

--- a/handler.py
+++ b/handler.py
@@ -89,7 +89,7 @@ class ViewParseAjaxHandler(BaseHandler):
         discoveredLinks = []
         outputLinks = []
         # ugh lol
-        regex = "[^/][`'\"]([\/][a-zA-Z0-9_.-]+)+(?!\/g|i|m|u|y|;|,)"
+        regex = r"[^/][`'\"]([\/][a-zA-Z0-9_.-]+)+(?!([gimuy]*[,;\s])|\/\2)"
         links = re.finditer(regex, contents) 
         for link in links:
             linkStr = link.group(0)


### PR DESCRIPTION
I closed my previous PR because of a typo. 
The refined regex is as follows;
```python
regex = "[^/][`'\"]([\/][a-zA-Z0-9_.-]+)+(?!\/g|i|m|u|y|;|,)"
```