### PR TITLE
python3 compatible print statement

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -172,7 +172,7 @@ class ViewParseAjaxHandler(BaseHandler):
                         continue
             # ignore if not json
             except:
-                print 'ignoring custom headers'
+                print("ignoring custom headers")
             if newHeaders:
                 sc._handle.setopt(pycurl.HTTPHEADER, newHeaders)
 


### PR DESCRIPTION
was erroring on Kali with:

 File "handler.py", line 175
    print 'ignoring custom headers'
                                  ^
SyntaxError: Missing parentheses in call to 'print'
