### PR TITLE
Add Dockerfile manifest for building an image of JSParser

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# docker pull andmyhacks/jsparser
+
+FROM python:2
+
+LABEL "Author"="Keith Hoodlet <keith@attackdriven.io>"
+
+RUN mkdir -p /var/www/jsparser
+WORKDIR /var/www/jsparser
+
+COPY . /var/www/jsparser/
+
+RUN apt-get update
+RUN apt-get install -y  git python-setuptools
+RUN pip install --upgrade pip
+
+RUN python setup.py install
+
+EXPOSE 8008
+ENTRYPOINT ["python", "handler.py"]


### PR DESCRIPTION
Hi NahamSec! I've created a Docker image for your **AWESOME** project, which can be built from the Dockerfile I've included with this pull request. The image can be pulled separately from Docker Hub at `https://hub.docker.com/r/andmyhacks/jsparser/` if you want to test the image before accepting the pull request.