### PR TITLE
Update handler.py

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -2,13 +2,16 @@ from __future__ import print_function
 import tornado.ioloop, tornado.web, tornado.autoreload
 from tornado.escape import json_encode, json_decode
 
-import safeurl, types, sys, re, mimetypes, glob, jsbeautifier, urlparse, pycurl
+import safeurl, types, sys, re, mimetypes, glob, jsbeautifier, pycurl
+from urllib.parse import urlparse
+from io import StringIO
+
 import calendar, time, datetime
 
 from netaddr import *
 from collections import defaultdict
 from bs4 import BeautifulSoup
-from cgi import escape
+from html import escape
 
 #------------------------------------------------------------
 # Base / Status Code Handlers


### PR DESCRIPTION
Remove error like urlparse with this one 

import safeurl, types, sys, re, mimetypes, glob, jsbeautifier, pycurl from urllib.parse import urlparse
from io import StringIO

and Remove error cannot import name 'escape' from 'cgi' (/usr/lib/python3.10/cgi.py)

from html import escape